### PR TITLE
Update dependencies to current, add lein ring hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This application support the [Getting Started with Clojure](https://devcenter.he
 
 Make sure you have Clojure installed.  Also, install the [Heroku Toolbelt](https://toolbelt.heroku.com/).
 
+First, clone the repo. Then you can change into the repo working directory and run the app.
+
+To run via `lein ring`:
+
+```sh
+$ lein ring server
+```
+
+To run in a REPL session:
+
 ```sh
 $ git clone https://github.com/heroku/clojure-getting-started.git
 $ cd clojure-getting-started

--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,13 @@
   :url "http://clojure-getting-started.herokuapp.com"
   :license {:name "Eclipse Public License v1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [compojure "1.4.0"]
-                 [ring/ring-jetty-adapter "1.4.0"]
-                 [environ "1.0.0"]]
-  :min-lein-version "2.0.0"
-  :plugins [[environ/environ.lein "0.3.1"]]
-  :hooks [environ.leiningen.hooks]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [compojure "1.6.1"]
+                 [ring/ring-jetty-adapter "1.7.1"]
+                 [environ "1.1.0"]]
+  :min-lein-version "2.7.2"
+  :plugins [[lein-environ "1.1.0"]
+            [lein-ring "0.12.4"]]
+  :ring {:handler clojure-getting-started.web/app}
   :uberjar-name "clojure-getting-started-standalone.jar"
   :profiles {:production {:env {:production true}}})


### PR DESCRIPTION
I'm running a session for beginners in a couple of weeks, just wanted to make sure the dependencies are up to date. 

Also, as most will probably be unfamiliar with the REPL at first, I wanted to make sure there was a CLI hook for quickly running `lein ring server` until we get a chance to discuss the REPL.

I've tested this by deploying it to a heroku stack [here](https://cryptic-scrubland-73236.herokuapp.com/).