### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Since all components in the Heroku Component Inventory are required to have one.

I've copied the config already used by `java-getting-started`:
https://github.com/heroku/java-getting-started/blob/main/.github/dependabot.yml

GUS-W-17981041.